### PR TITLE
support node 8.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bucharestgold/rpmbuild-base:8.1.0
+FROM bucharestgold/rpmbuild-base:8.3.0
 
 RUN mkdir -p /usr/src/node-rpm
 WORKDIR /usr/src/node-rpm/

--- a/src/nodejs.spec
+++ b/src/nodejs.spec
@@ -16,18 +16,18 @@
 # than a Fedora release lifecycle.
 %global nodejs_epoch 1
 %global nodejs_major 8
-%global nodejs_minor 2
-%global nodejs_patch 1
+%global nodejs_minor 3
+%global nodejs_patch 0
 %global nodejs_abi %{nodejs_major}.%{nodejs_minor}
 %global nodejs_version %{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}
 %global nodejs_release 1
 
 # == Bundled Dependency Versions ==
 # v8 - from deps/v8/include/v8-version.h
-%global v8_major 5
-%global v8_minor 8
-%global v8_build 283
-%global v8_patch 41
+%global v8_major 6
+%global v8_minor 0
+%global v8_build 286
+%global v8_patch 52
 # V8 presently breaks ABI at least every x.y release while never bumping SONAME
 %global v8_abi %{v8_major}.%{v8_minor}
 %global v8_version %{v8_major}.%{v8_minor}.%{v8_build}.%{v8_patch}


### PR DESCRIPTION
This commit adds support building RPMS for Node.js 8.3.0.