### PR TITLE
build: fix travis RPM output directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ services:
 - docker
 install:
 - docker build -t bucharestgold/fedora-node . 
-- docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS bucharestgold/fedora-node
+- docker run -it -v ${PWD}/rpms:/root/rpmbuild_usr_src_debug/RPMS bucharestgold/fedora-node
+
 before_deploy:
 - echo "Before deploy."
 deploy:


### PR DESCRIPTION
The directory path to the RPM was updated to account for a but in
rpmbuild but this update was not reflected in the travis configuration
leading to no RPMs being published when pushing a tag.