### PR TITLE
src: use tar instead of cloning a git repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 install:
 - docker build -t bucharestgold/node-rpm .
-- docker run -it -v ${PWD}/rpms:/root/rpmbuild_usr_src_debug/RPMS bucharestgold/node-rpm
+- docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS bucharestgold/node-rpm
 deploy:
   provider: releases
   api_key:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
 FROM bucharestgold/rhel-base
 
 USER root
-
 RUN mkdir -p /usr/src/node-rpm
-RUN mkdir -p /root/rpmbuild_usr_src_debug
-RUN git clone https://github.com/nodejs/node.git /root/rpmbuild_usr_src_debug/BUILD/nodejs
-RUN echo "%_topdir /root/rpmbuild_usr_src_debug" > ~/.rpmmacros
-
 WORKDIR /usr/src/node-rpm/
 
 COPY src/nodejs.spec src/run.sh /usr/src/node-rpm/
-COPY src/nodejs.spec /root/rpmbuild_usr_src_debug/SPECS/
+COPY src/nodejs.spec /root/rpmbuild/SPECS/
 
 COPY src/patches/0001-System-CA-Certificates.patch     \
-     src/nodejs_native.attr /root/rpmbuild_usr_src_debug/SOURCES/
+     src/nodejs_native.attr /root/rpmbuild/SOURCES/
 
 CMD ["./run.sh"]

--- a/src/nodejs-tarball.sh
+++ b/src/nodejs-tarball.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
-wget http://nodejs.org/dist/v${version}/node-v${version}.tar.gz
-tar -zxf node-v${version}.tar.gz
-rm -rf node-v${version}/deps/openssl
-tar -zcf node-v${version}-stripped.tar.gz node-v${version}

--- a/src/nodejs.spec
+++ b/src/nodejs.spec
@@ -150,7 +150,7 @@ The API documentation for the Node.js JavaScript runtime.
 
 
 %prep
-%setup -q -D -T -n node-v%{nodejs_version}
+%setup -q -n node-v%{nodejs_version}
 
 %patch1 -p1
 

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,27 +1,10 @@
 #!/bin/sh
 
 version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
-echo "Building with version $version"
+echo "Building version $version"
 
-old_build_dir=/root/rpmbuild_usr_src_debug/BUILD/nodejs
-new_build_dir=$(dirname $old_build_dir)/node-v${version}
-echo "old_build_dir:" ${old_build_dir}
-echo "new_build_dir:" ${new_build_dir}
-
-ln -s $old_build_dir $new_build_dir
-
-pushd ${new_build_dir}
-git fetch origin refs/tags/v${version}:refs/tags/v${version}
-## remove addons before checking out
-rm -rf test/addons
-rm -rf test/addons-napi
-git checkout -fb ${version} v${version}
-git checkout test/
-tar -zcf node-v${version}.tar.gz --transform "s/^node/node-v${version}/" $new_build_dir
-mv node-v${version}.tar.gz /root/rpmbuild_usr_src_debug/SOURCES
-popd
+curl -O http://nodejs.org/dist/v${version}/node-v${version}.tar.gz
+mv node-v${version}.tar.gz /root/rpmbuild/SOURCES
 
 ## Build the rpm
-pushd $(dirname $new_build_dir)
 rpmbuild -ba --noclean --define='basebuild 0' /usr/src/node-rpm/nodejs.spec
-popd


### PR DESCRIPTION
Instead of cloning a git repository this commit updates the run script
to download a node distribution. Later, when we have a fork/mirror of
node upstream we will update the download location.

Closes: #48