### PR TITLE
support node 8.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY src/nodejs.spec /root/rpmbuild/SPECS/
 COPY src/patches/0001-System-CA-Certificates.patch     \
      src/patches/0002-DNS-tests.patch                  \
      src/patches/0003-serdes.patch                     \
+     src/patches/0004-require-resolve-test.patch       \
      src/nodejs_native.attr /root/rpmbuild/SOURCES/
 
 CMD ["./run.sh"]

--- a/src/nodejs.spec
+++ b/src/nodejs.spec
@@ -12,7 +12,7 @@
 # == Node.js Version ==
 %global nodejs_epoch 1
 %global nodejs_major 8
-%global nodejs_minor 7
+%global nodejs_minor 8
 %global nodejs_patch 0
 %global nodejs_abi %{nodejs_major}.%{nodejs_minor}
 %global nodejs_version %{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}
@@ -71,6 +71,7 @@ Patch1: 0001-System-CA-Certificates.patch
 
 Patch2: 0002-DNS-tests.patch
 Patch3: 0003-serdes.patch
+Patch4: 0004-require-resolve-test.patch
 
 BuildRequires: python-devel
 BuildRequires: gcc >= 4.8.0
@@ -158,6 +159,7 @@ The API documentation for the Node.js JavaScript runtime.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 
 %build
 # build with debugging symbols and add defines from libuv (#892601)

--- a/src/patches/0004-require-resolve-test.patch
+++ b/src/patches/0004-require-resolve-test.patch
@@ -1,0 +1,15 @@
+---
+diff --git a/test/parallel/test-require-resolve.js b/test/parallel/test-require-resolve.js
+index 77f07b394f..b897936696 100644
+--- a/test/parallel/test-require-resolve.js
++++ b/test/parallel/test-require-resolve.js
+@@ -32,7 +32,7 @@ assert.strictEqual(
+   require.resolve(fixtures.path('a')).toLowerCase());
+ assert.strictEqual(
+   fixtures.path('nested-index', 'one', 'index.js').toLowerCase(),
+-  require.resolve(fixtures.path('nested-index', 'one').toLowerCase()));
++  require.resolve(fixtures.path('nested-index', 'one')).toLowerCase());
+ assert.strictEqual('path', require.resolve('path'));
+
+ console.log('ok');
+---

--- a/src/run.sh
+++ b/src/run.sh
@@ -3,11 +3,9 @@
 version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
 echo "Building version $version"
 
-curl -O http://nodejs.org/dist/v${version}/node-v${version}.tar.gz
-tar -zxf node-v${version}.tar.gz
-rm -rf node-v${version}/deps/openssl
-tar -zcf node-v${version}-stripped.tar.gz node-v${version}
-mv node-v${version}-stripped.tar.gz /root/rpmbuild/SOURCES/node-v${version}.tar.gz
+git clone https://github.com/bucharest-gold/node.git -b v${version}-rh node-v${version}
+tar -zcf node-v${version}.tar.gz node-v${version}
+mv node-v${version}.tar.gz /root/rpmbuild/SOURCES/node-v${version}.tar.gz
 
 ## Build the rpm
 rpmbuild -ba --noclean --define='basebuild 0' /usr/src/node-rpm/nodejs.spec


### PR DESCRIPTION
This commit adds support building RPMS for Node.js 8.8.0. A patch was
include to work around a failing test. A pull request has been sent
upstream so hopefully this patch can be removed with the next release.

This commit also starts using the bucharest-gold fork of node.