### PR TITLE
build: add a rh suffix to the tarball

### DIFF
--- a/src/nodejs.spec
+++ b/src/nodejs.spec
@@ -57,7 +57,7 @@ URL: http://nodejs.org/
 
 ExclusiveArch: %{nodejs_arches}
 
-Source0: node-v%{nodejs_version}.tar.gz
+Source0: node-v%{nodejs_version}-rh.tar.gz
 
 # The native module Requires generator remains in the nodejs SRPM, so it knows
 # the nodejs and v8 versions.  The remainder has migrated to the

--- a/src/run.sh
+++ b/src/run.sh
@@ -4,8 +4,8 @@ version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
 echo "Building version $version"
 
 git clone https://github.com/bucharest-gold/node.git -b v${version}-rh node-v${version}
-tar -zcf node-v${version}.tar.gz node-v${version}
-mv node-v${version}.tar.gz /root/rpmbuild/SOURCES/node-v${version}.tar.gz
+tar -zcf node-v${version}-rh.tar.gz node-v${version}
+mv node-v${version}-rh.tar.gz /root/rpmbuild/SOURCES/node-v${version}-rh.tar.gz
 
 ## Build the rpm
 rpmbuild -ba --noclean --define='basebuild 0' /usr/src/node-rpm/nodejs.spec


### PR DESCRIPTION
This commit adds a -rh suffix to the tarball to minimize the changes
required when we build with our internal system.