### PR TITLE
build: remove branch from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,5 @@ deploy:
   on:
     tags: true
     repo: bucharest-gold/node-rpm
-    branch: v8.x-staging
 notifications:
   irc: chat.freenode.net#bucharest-gold


### PR DESCRIPTION
This commit remove the branch property so that whenever a tag is pushed
it should be considered a release and build. Currently the new
v9.x-staging branch are not built for example.