### PR TITLE
clean up of scripts

### DIFF
--- a/0002-Internet.patch
+++ b/0002-Internet.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile b/Makefile
+index c2f872d..9eb389c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -976,15 +976,19 @@ lint-md-clean:
+	$(RM) -r tools/remark-preset-lint-node/node_modules
+ 
+ lint-md-build:
++ifndef no-internet
+	if [ ! -d tools/remark-cli/node_modules ]; then \
+		cd tools/remark-cli && ../../$(NODE) ../../$(NPM) install; fi
+	if [ ! -d tools/remark-preset-lint-node/node_modules ]; then \
+		cd tools/remark-preset-lint-node && ../../$(NODE) ../../$(NPM) install; fi
++endif
+ 
+ lint-md: lint-md-build
++ifndef no-internet
+	@echo "Running Markdown linter..."
+	$(NODE) tools/remark-cli/cli.js -q -f \
+		./*.md doc src lib benchmark tools/doc/ tools/icu/
++endif
+ 
+ LINT_JS_TARGETS = benchmark doc lib test tools
+ LINT_JS_CMD = tools/eslint/bin/eslint.js --cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 FROM openshift/base-centos7
 
-RUN yum install -y rpmdevtools git gcc gcc-c++ openssl-devel libicu-devel python-devel systemtap-sdt-devel make
+RUN yum install -y rpmdevtools         \
+                   git gcc gcc-c++     \
+                   openssl-devel       \
+                   libicu-devel        \
+                   python-devel        \
+                   systemtap-sdt-devel \
+                   make
 
 USER root
 RUN mkdir -p /usr/src/node-rpm
 WORKDIR /usr/src/node-rpm/
 
-COPY nodejs.spec run.sh /usr/src/node-rpm/
+COPY nodejs.spec run.sh create_node_tarball.sh /usr/src/node-rpm/
 COPY nodejs.spec /opt/app-root/src/rpmbuild/SPECS/
 
-COPY 0001-System-CA-Certificates.patch     \
+COPY 0001-System-CA-Certificates.patch             \
+     0002-Internet.patch                           \
      license_xml.js                                \
      license_html.js                               \
      licenses.css                                  \

--- a/create_node_tarball.sh
+++ b/create_node_tarball.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
+node_version=node-v${version}-rh
+
+git clone https://github.com/bucharest-gold/node.git -b v${version}-rh ${node_version}
+tar -zcf ${node_version}.tar.gz ${node_version}
+rm -rf ${node_version}

--- a/nodejs.spec
+++ b/nodejs.spec
@@ -68,6 +68,7 @@ Source7: nodejs_native.attr
 # modified version of Debian patch:
 # http://patch-tracker.debian.org/patch/series/view/nodejs/0.10.26~dfsg1-1/2014_donotinclude_root_certs.patch
 Patch1: 0001-System-CA-Certificates.patch
+Patch2: 0002-Internet.patch
 
 BuildRequires: python-devel
 BuildRequires: gcc >= 4.8.0
@@ -150,9 +151,10 @@ The API documentation for the Node.js JavaScript runtime.
 
 
 %prep
-%setup -q -n node-v%{nodejs_version}
+%setup -q -n node-v%{nodejs_version}-rh
 
 %patch1 -p1
+%patch2 -p1
 
 %build
 # build with debugging symbols and add defines from libuv (#892601)
@@ -179,9 +181,9 @@ export CXXFLAGS="$(echo ${CXXFLAGS} | tr '\n\\' '  ')"
 
 %if %{?with_debug} == 1
 # Setting BUILDTYPE=Debug builds both release and debug binaries
-make BUILDTYPE=Debug %{?_smp_mflags} test
+make BUILDTYPE=Debug %{?_smp_mflags} test no-internet=true
 %else
-make BUILDTYPE=Release %{?_smp_mflags} test
+make BUILDTYPE=Release %{?_smp_mflags} test no-internet=true
 %endif
 
 %install

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
-version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
-echo "Building version $version"
+export version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
+node_version=node-v${version}-rh
 
-git clone https://github.com/bucharest-gold/node.git -b v${version}-rh node-v${version}
-tar -zcf node-v${version}-rh.tar.gz node-v${version}
-mv node-v${version}-rh.tar.gz /opt/app-root/src/rpmbuild/SOURCES/node-v${version}-rh.tar.gz
+## Create the tarball
+./create_node_tarball.sh
+## Copy the tarball to SOURCES
+mv ${node_version}.tar.gz /opt/app-root/src/rpmbuild/SOURCES/${node_version}.tar.gz
 
 ## Build the rpm
 rpmbuild -ba --noclean --define='basebuild 0' /usr/src/node-rpm/nodejs.spec


### PR DESCRIPTION
This commit splits run.sh into two scripts so that it can be used in our
internal build system to manualy verify the contents of the tag to be
cloned.
This commit also adds a patch which is a temp patch to avoid attempting
to download the remark-cli module.