### PR TITLE
build: use Source variables for license files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,9 @@ RUN yum install -y rpmdevtools         \
                    make
 
 USER root
-RUN mkdir -p /usr/src/node-rpm
-WORKDIR /usr/src/node-rpm/
+WORKDIR /opt/app-root/src/rpmbuild/SPECS/
 
-COPY nodejs.spec run.sh create_node_tarball.sh /usr/src/node-rpm/
-COPY nodejs.spec /opt/app-root/src/rpmbuild/SPECS/
+COPY nodejs.spec run.sh create_node_tarball.sh /opt/app-root/src/rpmbuild/SPECS/
 
 COPY 0001-System-CA-Certificates.patch             \
      0002-Internet.patch                           \

--- a/nodejs.spec
+++ b/nodejs.spec
@@ -58,6 +58,9 @@ URL: http://nodejs.org/
 ExclusiveArch: %{nodejs_arches}
 
 Source0: node-v%{nodejs_version}-rh.tar.gz
+Source1: license_xml.js
+Source2: license_html.js
+Source3: licenses.css
 
 # The native module Requires generator remains in the nodejs SRPM, so it knows
 # the nodejs and v8 versions.  The remainder has migrated to the
@@ -219,7 +222,7 @@ chmod 0755 %{buildroot}%{_rpmconfigdir}/nodejs_native.req
 mkdir -p %{buildroot}%{_pkgdocdir}/html
 cp -pr doc/* %{buildroot}%{_pkgdocdir}/html
 rm -f %{buildroot}%{_pkgdocdir}/html/nodejs.1
-cp %{_sourcedir}/licenses.css licenses.css
+cp %{SOURCE3} licenses.css
 
 #node-gyp needs common.gypi too
 mkdir -p %{buildroot}%{_datadir}/node
@@ -272,8 +275,8 @@ ln -sf %{_pkgdocdir}/npm/html %{buildroot}%{_prefix}/lib/node_modules/npm/doc
 NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -e "require(\"assert\").equal(require(\"npm\").version, '%{npm_version}')"
 
 # Generate license.xml and license.html
-%{buildroot}/%{_bindir}/node %{_sourcedir}/license_xml.js 'node' '%{nodejs_version}' > license.xml
-%{buildroot}/%{_bindir}/node %{_sourcedir}/license_html.js 'node' > license.html
+%{buildroot}/%{_bindir}/node %{SOURCE1} 'node' '%{nodejs_version}' > license.xml
+%{buildroot}/%{_bindir}/node %{SOURCE2} 'node' > license.html
 
 %files
 %{_bindir}/node

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,4 @@ node_version=node-v${version}-rh
 mv ${node_version}.tar.gz /opt/app-root/src/rpmbuild/SOURCES/${node_version}.tar.gz
 
 ## Build the rpm
-rpmbuild -ba --noclean --define='basebuild 0' /usr/src/node-rpm/nodejs.spec
+rpmbuild -ba --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec


### PR DESCRIPTION
This commit adds three source variables for the license files and uses
them instead of the hard codes license files and paths that were
previously used. It also moves create_node_tarball.sh and run.sh to the
SPECS directory to mimic where they would be on our internal build
system.