### PR TITLE
build: update path to RPMS on docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 install:
 - docker build -t bucharestgold/node-rpm .
-- docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS bucharestgold/node-rpm
+- docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
This commit updates the location of the RPMS so that Travis's deployment
functionality can pick up the generated RPMS.