### PR TITLE
add support for 9.5.0

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -287,6 +287,7 @@ NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -
 
 %files -n npm
 %{_bindir}/npm
+%{_bindir}/npx
 %{_prefix}/lib/node_modules/npm
 %ghost %{_sysconfdir}/npmrc
 %ghost %{_sysconfdir}/npmignore

--- a/nodejs.spec
+++ b/nodejs.spec
@@ -16,7 +16,7 @@
 %global nodejs_patch 0
 %global nodejs_abi %{nodejs_major}.%{nodejs_minor}
 %global nodejs_version %{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}
-%global nodejs_release 1
+%global nodejs_release 2
 
 # == Bundled Dependency Versions ==
 # v8 - from deps/v8/include/v8-version.h
@@ -106,17 +106,6 @@ for easily building fast, scalable network applications.
 Node.js uses an event-driven, non-blocking I/O model that
 makes it lightweight and efficient, perfect for data-intensive
 real-time applications that run across distributed devices.
-
-%package devel
-Summary: JavaScript runtime - development headers
-Group: Development/Languages
-Requires: %{name}%{?_isa} = %{epoch}:%{nodejs_version}-%{nodejs_release}%{?dist}
-Requires: openssl-devel%{?_isa}
-Requires: zlib-devel%{?_isa}
-Requires: nodejs-packaging
-
-%description devel
-Development headers for the Node.js JavaScript runtime.
 
 %package -n npm
 Summary: Node.js Package Manager
@@ -288,16 +277,6 @@ NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -
 %doc AUTHORS CHANGELOG.md COLLABORATOR_GUIDE.md GOVERNANCE.md README.md
 %doc %{_mandir}/man*/*
 
-
-%files devel
-%if %{?with_debug} == 1
-%{_bindir}/node_g
-%endif
-%{_includedir}/node
-%{_datadir}/node/common.gypi
-%{_pkgdocdir}/gdbinit
-%{_pkgdocdir}/lldbinit
-%{_pkgdocdir}/lldb_commands.py
 
 
 %files -n npm

--- a/nodejs.spec
+++ b/nodejs.spec
@@ -12,7 +12,7 @@
 # == Node.js Version ==
 %global nodejs_epoch 1
 %global nodejs_major 9
-%global nodejs_minor 4
+%global nodejs_minor 5
 %global nodejs_patch 0
 %global nodejs_abi %{nodejs_major}.%{nodejs_minor}
 %global nodejs_version %{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}
@@ -23,7 +23,7 @@
 %global v8_major 6
 %global v8_minor 2
 %global v8_build 414
-%global v8_patch 46-node.17
+%global v8_patch 46-node.18
 # V8 presently breaks ABI at least every x.y release while never bumping SONAME
 %global v8_abi %{v8_major}.%{v8_minor}
 %global v8_version %{v8_major}.%{v8_minor}.%{v8_build}.%{v8_patch}

--- a/nodejs.spec
+++ b/nodejs.spec
@@ -162,6 +162,9 @@ export CXXFLAGS='%{optflags} -g \
 export CFLAGS="$(echo ${CFLAGS} | tr '\n\\' '  ')"
 export CXXFLAGS="$(echo ${CXXFLAGS} | tr '\n\\' '  ')"
 
+# Generate the headers tar-ball
+make tar-headers
+
 ./configure --prefix=%{_prefix} \
            --shared-openssl \
            --with-dtrace \
@@ -208,6 +211,8 @@ cp %{SOURCE3} licenses.css
 #node-gyp needs common.gypi too
 mkdir -p %{buildroot}%{_datadir}/node
 cp -p common.gypi %{buildroot}%{_datadir}/node
+
+cp -p node-v%{nodejs_version}-headers.tar.gz %{buildroot}%{_datadir}/node
 
 # Install the GDB init and lldbinit tools into the documentation directory
 mv %{buildroot}/%{_datadir}/doc/node/gdbinit %{buildroot}/%{_pkgdocdir}/gdbinit
@@ -266,6 +271,7 @@ NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -
 %dir %{_datadir}/systemtap
 %dir %{_datadir}/systemtap/tapset
 %{_datadir}/systemtap/tapset/node.stp
+%{_datadir}/node/node-v%{nodejs_version}-headers.tar.gz
 %dir %{_usr}/lib/dtrace
 %{_usr}/lib/dtrace/node.d
 %{_rpmconfigdir}/fileattrs/nodejs_native.attr


### PR DESCRIPTION
These commits add support for Node 9.5.0 and include a few from the v8.x-staging branch.