### PR TITLE
src: re-enable headers tar.gz

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -170,8 +170,12 @@ export CXXFLAGS='%{optflags} -g \
 export CFLAGS="$(echo ${CFLAGS} | tr '\n\\' '  ')"
 export CXXFLAGS="$(echo ${CXXFLAGS} | tr '\n\\' '  ')"
 
+git config user.email "daniel.bevenius@gmail.com"
+git config user.name "Daniel Bevenius"
+git add test/parallel/test-tls-cnnic-whitelist.js
+git commit -m 'test: commit to allow tar-headers to pass'
 # Generate the headers tar-ball
-#make tar-headers
+make tar-headers
 
 ./configure --prefix=%{_prefix} \
            --shared-openssl \
@@ -220,7 +224,7 @@ cp %{SOURCE3} licenses.css
 mkdir -p %{buildroot}%{_datadir}/node
 cp -p common.gypi %{buildroot}%{_datadir}/node
 
-#cp -p node-v%{nodejs_version}-headers.tar.gz %{buildroot}%{_datadir}/node
+cp -p node-v%{nodejs_version}-headers.tar.gz %{buildroot}%{_datadir}/node
 
 # Install the GDB init and lldbinit tools into the documentation directory
 mv %{buildroot}/%{_datadir}/doc/node/gdbinit %{buildroot}/%{_pkgdocdir}/gdbinit
@@ -281,7 +285,7 @@ NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -
 %dir %{_datadir}/systemtap
 %dir %{_datadir}/systemtap/tapset
 %{_datadir}/systemtap/tapset/node.stp
-#%{_datadir}/node/node-v%{nodejs_version}-headers.tar.gz
+%{_datadir}/node/node-v%{nodejs_version}-headers.tar.gz
 %dir %{_usr}/lib/dtrace
 %{_usr}/lib/dtrace/node.d
 %{_rpmconfigdir}/fileattrs/nodejs_native.attr


### PR DESCRIPTION
The generation of the headers tar.gz was commented out because after
applying the patch it failed as there were uncommitted changes. We now
commit the patched test and can proceed with generating the tar.
The commit is never used as we build in a detached head but that is
fine.