### PR TITLE
build: fix verbose make variable and remove quite

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -181,9 +181,9 @@ make tar-headers
 
 %if %{?with_debug} == 1
 # Setting BUILDTYPE=Debug builds both release and debug binaries
-make V=0 BUILDTYPE=Debug %{?_smp_mflags} test-only
+make V= BUILDTYPE=Debug %{?_smp_mflags} test-only
 %else
-make V=0 BUILDTYPE=Release %{?_smp_mflags} test-only
+make V= BUILDTYPE=Release %{?_smp_mflags} test-only
 %endif
 
 %install

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,4 @@ node_version=node-v${version}-rh
 mv ${node_version}.tar.gz /opt/app-root/src/rpmbuild/SOURCES/${node_version}.tar.gz
 
 ## Build the rpm
-rpmbuild -ba --quiet --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec
+rpmbuild -ba --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec


### PR DESCRIPTION
This commit updates the verbose variable which is currently V=0 to be V=
which should reduce the output genereated by make considerably but also
allow us to inspect any failure. Therefore this commit also removed the
quite rpmbuild option so that we can still see potential failures.