### PR TITLE
build: support arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services:
 install:
 #- docker build -t bucharestgold/node-rpm .
 #- docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
+## prepare qemu
+- docker run --rm --privileged multiarch/qemu-user-static:register --reset
 - docker build -f Dockerfile.arm64v8 -t bucharestgold/node-arm-rpm .
 - docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-arm-rpm
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: generic
 services:
 - docker
 install:
-- docker build -t bucharestgold/node-rpm .
-- docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
+#- docker build -t bucharestgold/node-rpm .
+#- docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
 - docker build -f Dockerfile.arm64v8 -t bucharestgold/node-arm-rpm .
 - docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-arm-rpm
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services:
 install:
 - docker build -t bucharestgold/node-rpm .
 - docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
+- docker build -f Dockerfile.arm64v8 -t bucharestgold/node-arm-rpm .
+- docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-arm-rpm
 deploy:
   provider: releases
   api_key:

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,5 +1,6 @@
 FROM arm64v8/centos
 
+RUN echo "here........"
 RUN yum install -y rpmdevtools         \
                    git gcc gcc-c++     \
                    openssl-devel       \
@@ -7,6 +8,7 @@ RUN yum install -y rpmdevtools         \
                    python-devel        \
                    systemtap-sdt-devel \
                    make                \
+                   which               \
                    qemu-kvm            \
                    qemu-img
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM arm64v8/centos
 
 RUN yum install -y rpmdevtools         \
                    git gcc gcc-c++     \
@@ -6,11 +6,12 @@ RUN yum install -y rpmdevtools         \
                    libicu-devel        \
                    python-devel        \
                    systemtap-sdt-devel \
-                   make
+                   make                \
+                   which
 
 USER root
+ENV RPMBUILD_DIR="/root/rpmbuild/"
 
-ENV RPMBUILD_DIR="/opt/app-root/src/rpmbuild"
 WORKDIR ${RPMBUILD_DIR}/SPECS/
 
 COPY nodejs.spec run.sh create_node_tarball.sh ${RPMBUILD_DIR}/SPECS/

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -7,7 +7,8 @@ RUN yum install -y rpmdevtools         \
                    python-devel        \
                    systemtap-sdt-devel \
                    make                \
-                   which
+                   which               \
+                   qemu-kvm qemu-img
 
 USER root
 ENV RPMBUILD_DIR="/root/rpmbuild/"

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -7,7 +7,6 @@ RUN yum install -y rpmdevtools         \
                    python-devel        \
                    systemtap-sdt-devel \
                    make                \
-                   which               \
                    qemu-kvm            \
                    qemu-img
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -8,7 +8,8 @@ RUN yum install -y rpmdevtools         \
                    systemtap-sdt-devel \
                    make                \
                    which               \
-                   qemu-kvm qemu-img
+                   qemu-kvm            \
+                   qemu-img
 
 USER root
 ENV RPMBUILD_DIR="/root/rpmbuild/"

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,16 +1,7 @@
 FROM arm64v8/centos
 
-RUN echo "here........"
-RUN yum install -y rpmdevtools         \
-                   git gcc gcc-c++     \
-                   openssl-devel       \
-                   libicu-devel        \
-                   python-devel        \
-                   systemtap-sdt-devel \
-                   make                \
-                   which               \
-                   qemu-kvm            \
-                   qemu-img
+RUN ["/usr/bin/sh", "-c", "echo 'here........'"]
+RUN ["/usr/bin/sh", "-c", "yum install -y rpmdevtools git gcc gcc-c++ openssl-devel libicu-devel python-devel systemtap-sdt-devel make which qemu-kvm qemu-img"]
 
 USER root
 ENV RPMBUILD_DIR="/root/rpmbuild/"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Then run the following command to build the RPM:
 
     $ ./run.sh
 
+#### Building for ARM
+
+    $ docker build -f Dockerfile.arm64v8 -t bucharestgold/node-arm-rpm .
+
 ### Built RPMs
 The build RPMS can be found in the [rpms](./rpms) directory and are also [published][] when a tag is pushed.
 

--- a/parse_target_arch.py
+++ b/parse_target_arch.py
@@ -1,0 +1,5 @@
+options = {}
+with open('config.gypi') as file:
+    options = eval(file.read())
+
+print options['variables']['target_arch']

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ node_version=node-v${version}-rh
 ## Create the tarball
 ./create_node_tarball.sh
 ## Copy the tarball to SOURCES
-mv ${node_version}.tar.gz /opt/app-root/src/rpmbuild/SOURCES/${node_version}.tar.gz
+mv ${node_version}.tar.gz ${RPMBUILD_DIR}/SOURCES/${node_version}.tar.gz
 
 ## Build the rpm
-rpmbuild -ba --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec
+rpmbuild -ba --noclean --define='basebuild 0' ${RPMBUILD_DIR}/SPECS/nodejs.spec


### PR DESCRIPTION
This commit is an initial commit for supporting ARM achitectures. The
goal of this commit is to discover any issues there might be and come up
with a configuration that builds, which can then be built out has needed.

Travis has also been updated but it remains to see if travis can handle
the longer build time. If not we should look into being able to split
the work up and only run one architecture at a time.

Refs: https://github.com/bucharest-gold/node-rpm/issues/138