### PR TITLE
feat: Adds a new environment variable to the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 install:
 - docker build -t bucharestgold/node-rpm .
-- docker run -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
+- docker run -e SILENT=true -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
 deploy:
   provider: releases
   api_key:

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,8 @@ node_version=node-v${version}-rh
 mv ${node_version}.tar.gz /opt/app-root/src/rpmbuild/SOURCES/${node_version}.tar.gz
 
 ## Build the rpm
-rpmbuild -ba --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec
+if [ $SILENT == "true" ]; then
+  rpmbuild -ba --quiet --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec
+else
+  rpmbuild -ba --noclean --define='basebuild 0' /opt/app-root/src/rpmbuild/SPECS/nodejs.spec
+fi


### PR DESCRIPTION
By adding a silent=true ENV var we can switch between builds with logs
for travis CI and builds without logs for local builds.

example:

docker run -e silent=true -it -v RPMS bucharestgold/node-rpm
docker run -it -v RPMS bucharestgold/node-rpm