### PR TITLE
src: add fips support

### DIFF
--- a/create_node_tarball.sh
+++ b/create_node_tarball.sh
@@ -4,5 +4,13 @@ version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
 node_version=node-v${version}-rh
 
 git clone https://github.com/bucharest-gold/node.git -b v${version}-rh ${node_version}
+
+## Download the FIPS Module
+openssl_fips=openssl-fips-2.0.16
+openssl_fips_tarball=${openssl_fips}.tar.gz
+curl -LO https://openssl.org/source/${openssl_fips_tarball}
+gzip -dc ${openssl_fips_tarball} | tar xf -
+mv ${openssl_fips} ${node_version}/deps/openssl_fips
+
 tar -zcf ${node_version}.tar.gz ${node_version}
 rm -rf ${node_version}


### PR DESCRIPTION
This commit add FIPS support for 8.x by producing an rpm which has been
compiled and linked to the fips module.

Currently the fips module is downloaded, but later we will probably add
this to our node fork and just have that unpacked. When that happens we
can remove the downloading from create_node_tarball.sh and that should
be the only change required.

There is an issue with this currently which is that the fips rpm cannot
have the same name for the node executable. Instread it is named
node_fips. It is up to the user of the rpm to create a logical link if
this name is not acceptable.