### PR TITLE
build: add support for building with RHEL 8

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -122,11 +122,7 @@ Release: %{npm_release}%{?dist}
 
 Obsoletes: npm < 0:3.5.4-6
 Provides: npm = %{npm_epoch}:%{npm_version}
-%if 0%{?rhel} > 7
-Requires: nodejs = %{epoch}:%{nodejs_version}-%{nodejs_release}%{?dist}
-%else
-Requires: rhoar-nodejs = %{epoch}:%{nodejs_version}-%{nodejs_release}%{?dist}
-%endif
+Requires: %{name} = %{epoch}:%{nodejs_version}-%{nodejs_release}%{?dist}
 
 # Do not add epoch to the virtual NPM provides or it will break
 # the automatic dependency-generation script.


### PR DESCRIPTION
This commit contains modifications to the spec file to allow building on
RHEL-8. This is only done for production builds but since we use the
same spec file for both it makes changes to other parts of the spec file
easier than having completely separate spec.files.