### PR TITLE
build: add base image for Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: generic
 services:
 - docker
 install:
-- docker build -t bucharestgold/node-rpm .
-- docker run -e SILENT=true -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS bucharestgold/node-rpm
+- docker build -t nodeshift/node-rpm .
+script:
+- docker run -e SILENT=true -it -v ${PWD}/rpms:/opt/app-root/src/rpmbuild/RPMS nodeshift/node-rpm
 deploy:
   provider: releases
   api_key:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,16 @@
-FROM openshift/base-centos7
-
-RUN yum install -y centos-release-scl  && \
-    yum remove -y  gcc                 && \
-    yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++  && \
-    yum install -y rpmdevtools            \
-                   git                    \
-                   openssl-devel          \
-                   libicu-devel           \
-                   python-devel           \
-                   systemtap-sdt-devel    \
-                   make              
+FROM nodeshift/node12-base:latest
 
 ENV PATH $PATH:/opt/rh/devtoolset-7/root/usr/bin
 
 USER root
 WORKDIR /opt/app-root/src/rpmbuild/SPECS/
 
-COPY nodejs.spec run.sh create_node_tarball.sh /opt/app-root/src/rpmbuild/SPECS/
+COPY nodejs.spec run.sh /opt/app-root/src/rpmbuild/SPECS/
 
 COPY license_xml.js                                            \
      license_html.js                                           \
      licenses.css                                              \
+     node_version.patch                                        \
      nodejs_native.attr /opt/app-root/src/rpmbuild/SOURCES/
 
 CMD ["./run.sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,24 @@
+FROM openshift/base-centos7
+
+RUN yum install -y centos-release-scl  && \
+    yum remove -y  gcc                 && \
+    yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++  && \
+    yum install -y rpmdevtools            \
+                   git                    \
+                   openssl-devel          \
+                   libicu-devel           \
+                   python-devel           \
+                   systemtap-sdt-devel    \
+                   make
+
+ARG VERSION_TAG=v12.0.0-rh
+ENV PATH "$PATH:/opt/rh/devtoolset-7/root/usr/bin"
+ENV BUILD_DIR "/opt/app-root/src/rpmbuild/BUILD"
+
+RUN mkdir -p ${BUILD_DIR} && \
+    git clone https://github.com/nodeshift/node.git -b ${VERSION_TAG}  ${BUILD_DIR}/node && \
+    cd ${BUILD_DIR}/node && \
+    export CFLAGS="`rpm --eval "%{optflags}"` -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DZLIB_CONST -fno-delete-null-pointer-checks" && \
+    export CXXFLAGS="`rpm --eval "%{optflags}"` -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DZLIB_CONST -fno-delete-null-pointer-checks" && \
+    ./configure --prefix=usr --with-dtrace && \
+    make -s V=1 BUILDTYPE=Release -j4

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ The RPM [spec file](./src/nodejs.spec) was based on the spec file from this
 ### Releases 
 Built releases are [published][] on github
 
+#### Re-building base image
+```console
+$ docker build -t nodeshift/node12-base - < Dockerfile.base
+```
+Push to docker:
+```console
+$ docker login username
+$ docker push nodeshift/node12-base
+```
+
 ### Building a new RPM
 If there is a new version released for Node.js and there is no existing staging branch for that version
 a branch should be created.
@@ -25,17 +35,21 @@ easier to run the build locally to identify the failure if there are any.
 
 ### Running the build locally
 
+#### Build the base image
+
+    $ docker build -t nodeshift/node12-base - < Dockerfile.base
+
 #### Build the docker image
 
-    $ docker build -t bucharestgold/centos-node .
+    $ docker build -t nodeshift/centos-node .
 
 #### Run the docker image
 
-    $ docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS bucharestgold/centos-node
+    $ docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS nodeshift/centos-node
 
 #### Run the build manually
 
-    $ docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS bucharestgold/centos-node bash
+    $ docker run -it -v ${PWD}/rpms:/root/rpmbuild/RPMS nodeshift/centos-node bash
 
 Then run the following command to build the RPM:
 

--- a/make_build_addons.patch
+++ b/make_build_addons.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 062d70b..94564e8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -391,7 +391,8 @@ test/addons/.buildstamp: $(ADDONS_PREREQS) \
+ # .buildstamp is out of date and need a rebuild.
+ # Just goes to show that recursive make really is harmful...
+ # TODO(bnoordhuis) Force rebuild after gyp update.
+-build-addons: | $(NODE_EXE) test/addons/.buildstamp
++build-addons: | $(NODE_EXE)
++	$(MAKE) test/addons/.buildstamp
+ 
+ JS_NATIVE_API_BINDING_GYPS := \
+ 	$(filter-out test/js-native-api/??_*/binding.gyp, \

--- a/node_version.patch
+++ b/node_version.patch
@@ -1,0 +1,13 @@
+diff --git a/src/node_version.h b/src/node_version.h
+index efe7970eaf..10c8d54f13 100644
+--- a/src/node_version.h
++++ b/src/node_version.h
+@@ -29,7 +29,7 @@
+ #define NODE_VERSION_IS_LTS 0
+ #define NODE_VERSION_LTS_CODENAME ""
+
+-#define NODE_VERSION_IS_RELEASE 0
++#define NODE_VERSION_IS_RELEASE 1
+
+ #ifndef NODE_STRINGIFY
+ #define NODE_STRINGIFY(n) NODE_STRINGIFY_HELPER(n)

--- a/nodejs.spec
+++ b/nodejs.spec
@@ -11,8 +11,8 @@
 
 # == Node.js Version ==
 %global nodejs_epoch 1
-%global nodejs_major 11
-%global nodejs_minor 12
+%global nodejs_major 12
+%global nodejs_minor 0
 %global nodejs_patch 0
 %global nodejs_abi %{nodejs_major}.%{nodejs_minor}
 %global nodejs_version %{nodejs_major}.%{nodejs_minor}.%{nodejs_patch}
@@ -21,9 +21,9 @@
 # == Bundled Dependency Versions ==
 # v8 - from deps/v8/include/v8-version.h and v8_embedder_string from common.gypi
 %global v8_major 7
-%global v8_minor 0
-%global v8_build 276
-%global v8_patch 38-node.18
+%global v8_minor 3
+%global v8_build 492
+%global v8_patch 25-node.7
 # V8 presently breaks ABI at least every x.y release while never bumping SONAME
 %global v8_abi %{v8_major}.%{v8_minor}
 %global v8_version %{v8_major}.%{v8_minor}.%{v8_build}.%{v8_patch}
@@ -57,7 +57,6 @@ URL: http://nodejs.org/
 
 ExclusiveArch: %{nodejs_arches}
 
-Source0: node-v%{nodejs_version}-rh.tar.gz
 Source1: license_xml.js
 Source2: license_html.js
 Source3: licenses.css
@@ -67,7 +66,7 @@ Source3: licenses.css
 # nodejs-packaging SRPM.
 Source7: nodejs_native.attr
 
-#Patch1: 0001-tar-headers.patch
+Patch1: node_version.patch
 
 BuildRequires: python-devel
 BuildRequires: devtoolset-7-gcc
@@ -141,9 +140,9 @@ Conflicts: %{name} < %{epoch}:%{nodejs_version}-%{nodejs_release}%{?dist}
 The API documentation for the Node.js JavaScript runtime.
 
 %prep
-%setup -q -n node-v%{nodejs_version}-rh
+%setup -q -D -T 
 
-#%patch1 -p1
+%patch1 -p1
 
 %build
 scl enable devtoolset-7 - << \EOF
@@ -151,36 +150,20 @@ set -ex
 # build with debugging symbols and add defines from libuv (#892601)
 # Node's v8 breaks with GCC 6 because of incorrect usage of methods on
 # NULL objects. We need to pass -fno-delete-null-pointer-checks
-export CFLAGS='%{optflags} -g \
-               -D_LARGEFILE_SOURCE \
-               -D_FILE_OFFSET_BITS=64 \
-               -DZLIB_CONST \
-               -fno-delete-null-pointer-checks'
-export CXXFLAGS='%{optflags} -g \
-                 -D_LARGEFILE_SOURCE \
-                 -D_FILE_OFFSET_BITS=64 \
-                 -DZLIB_CONST \
-                 -fno-delete-null-pointer-checks'
+export CFLAGS='%{optflags} -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DZLIB_CONST -fno-delete-null-pointer-checks'
+export CXXFLAGS='%{optflags} -g -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DZLIB_CONST -fno-delete-null-pointer-checks'
 
-# Explicit new lines in C(XX)FLAGS can break naive build scripts
-export CFLAGS="$(echo ${CFLAGS} | tr '\n\\' '  ')"
-export CXXFLAGS="$(echo ${CXXFLAGS} | tr '\n\\' '  ')"
-
-#git config user.email "daniel.bevenius@gmail.com"
-#git config user.name "Daniel Bevenius"
-#git add tools/install.py
-#git commit -m 'test: commit to allow tar-headers to pass'
+sed -i 's/REPLACEME/%{nodejs_version}/g' doc/api/*.md
+git config user.email "daniel.bevenius@gmail.com"
+git config user.name "Daniel Bevenius"
+git add doc/api src
+git commit -m 'test: commit to allow tar-headers to pass'
 # Generate the headers tar-ball
 make tar-headers
-
 ./configure --prefix=%{_prefix} --with-dtrace
-
-%if %{?with_debug} == 1
-# Setting BUILDTYPE=Debug builds both release and debug binaries
-make -s V= BUILDTYPE=Debug %{?_smp_mflags} test
-%else
-make -s V= BUILDTYPE=Release %{?_smp_mflags} test
-%endif
+make -s V=0 BUILDTYPE=Release %{?_smp_mflags}
+make -s V=0 BUILDTYPE=Release -j1 build-addons
+make -s V=0 BUILDTYPE=Release %{?_smp_mflags} test
 EOF
 
 %install
@@ -304,6 +287,8 @@ NODE_PATH=%{buildroot}%{_prefix}/lib/node_modules %{buildroot}/%{_bindir}/node -
 %{_pkgdocdir}/npm/doc
 
 %changelog
+* Tue Mar 26 2019 Daniel Bevenius <daniel.bevenius@gmail.com> - 12.0.0-1
+- Updated to use version pre-release 12.0.0
 * Thu Mar 21 2019 Helio Frota <hesilva@redhat.com> - 11.12.0-1
 - Updated to use version 11.12.0
 * Thu Mar 7 2019 Helio Frota <hesilva@redhat.com> - 11.11.0-1

--- a/run.sh
+++ b/run.sh
@@ -3,10 +3,11 @@
 export version=$(rpm -q --specfile --qf='%{version}\n' nodejs.spec | head -n1)
 node_version=node-v${version}-rh
 
-## Create the tarball
-./create_node_tarball.sh
-## Copy the tarball to SOURCES
-mv ${node_version}.tar.gz /opt/app-root/src/rpmbuild/SOURCES/${node_version}.tar.gz
+pushd /opt/app-root/src/rpmbuild/BUILD/node
+git checkout v${version}-rh
+cd ..
+ln -s node rhoar-nodejs-${version}
+popd
 
 ## Build the rpm
 if [ $SILENT == "true" ]; then


### PR DESCRIPTION
This commit introduces a base image which contains a compiled base of
Node.js 12. This base image is then used by the normal docker container
and the goal is to speed up the build time which is currently exeeding
the maximum allowed on travis.